### PR TITLE
Add Add(Assign) methods for KahanSum (#1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kahan"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Mark Sherry <mdsherry@gmail.com>"]
 description = "Provides types to perform Kahan summation"
 documentation = "https://docs.rs/kahan/0.1.0/kahan/"
@@ -11,5 +11,5 @@ categories = ["algorithms"]
 license = "Apache-2.0"
 
 [dependencies]
-num-traits = "0.1"
+num-traits = "0.2"
 


### PR DESCRIPTION
`(a + b + c) + (d + e + f) != a + b + c + d + e + f`, sadly; you can
expect at least the error term to be different. However, it should be
more accurate than ignoring the error term completely.